### PR TITLE
Add option for plural topics

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
 			<legend>Options</legend>
 			<label for='inputTopic'> Topic: </label>
 			<input type=text id='inputTopic' placeholder='Silicate Chemistry'></input>
+			<label for='inputPluralTopic'> Plural Topic: </label>
+			<input type=checkbox id='inputPluralTopic' ></input>
 			<label for='inputExperts'> Experts: </label>
 			<input type=text id='inputExperts' placeholder='Geochemists'></input>
 			<label for='inputExample'> Example: </label>

--- a/script.js
+++ b/script.js
@@ -24,11 +24,14 @@ buttonCopy.addEventListener('click', async function copyImage() {
 
 function draw() {
 	let topic = inputTopic.value || 'Silicate Chemistry';
+	let plural_topic = inputPluralTopic.checked;
 	let experts = inputExperts.value || 'Geochemists';
 	let example = inputExample.value || 'The formulas for olivine and one or two feldspars';
 	let response = inputResponse.value || 'Quartz';
 	
-	let text1 = `${topic} is second nature to us ${experts}, so it's easy to forget that the average person probably only knows ${example}.`
+	let topic_verb = plural_topic ? 'are' : 'is'; 
+
+	let text1 = `${topic} ${topic_verb} second nature to us ${experts}, so it's easy to forget that the average person probably only knows ${example}.`
 	let text2 = `And ${response}, of course`
 	
 	ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -85,6 +88,7 @@ function init() {
 	
 	let params = new URLSearchParams(document.location.search);
 	inputTopic.value = params.get('topic');
+	inputPluralTopic.checked = params.get('plural_topic');
 	inputExperts.value = params.get('experts');
 	inputExample.value = params.get('example');
 	inputResponse.value = params.get('response');


### PR DESCRIPTION
I saw a few people asking for a way to switch the word "Is" after the topic to "Are", so I quickly hacked it. This adds a "plural topic" option, which just swaps out the word. Very minimal changes.

(Cool project, BTW! I've worked on making this exact thing, but never got very far. Great to see someone do it!)