### PR TITLE
Implement i18n

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 		<section id='buttons'>
 			<button id='buttonCopy'>Copy to Clipboard</button>
 			<button id='buttonSave'>Save Image</button>
+      <select id='localeSelector'></select>
 		</section>
 	</main>
 	<footer>

--- a/script.js
+++ b/script.js
@@ -8,7 +8,9 @@ const locales = {
     defaultResponse: 'Quartz',
     templateTopSingular: "{topic} is second nature to us {experts}, so it's easy to forget that the average person probably only knows {example}.",
     templateTopPlural: "{topic} are second nature to us {experts}, so it's easy to forget that the average person probably only knows {example}.",
-    templateBottom: "And {response}, of course."
+    templateBottom: 'And {response}, of course.',
+    ofCourse: 'Of course.',
+    textUnder: "Even when they're trying to compensate for it, experts in anything wildly overestimate the average person's familiarity with their field."
   },
   pt: {
     localeName: 'Português',
@@ -17,9 +19,11 @@ const locales = {
     defaultExperts: 'Geoquímicos',
     defaultExample: 'As fórmulas de olivina e um ou dois feldspatos',
     defaultResponse: 'Quartzo',
-    templateTopSingular: "{topic} é algo natural para nós, {experts}, por isso é fácil esquecer que pessoas comuns provavelmente só sabem {example}.",
-    templateTopPlural: "{topic} são coisas naturais para nós, {experts}, por isso é fácil esquecer que pessoas comuns provavelmente só sabem {example}.",
-    templateBottom: "E {response}, é claro."
+    templateTopSingular: '{topic} é algo natural para nós, {experts}, por isso é fácil esquecer que pessoas comuns provavelmente só conhecem {example}.',
+    templateTopPlural: '{topic} são coisas naturais para nós, {experts}, por isso é fácil esquecer que pessoas comuns provavelmente só conhecem {example}.',
+    templateBottom: 'E {response}, é claro.',
+    ofCourse: 'É claro.',
+    textUnder: 'Mesmo quando eles tentam compensar por isso, especialistas de qualquer assunto superestimam o conhecimento das pessoas comuns com seu campo de estudo.'
   }
 };
 
@@ -37,8 +41,8 @@ localeSelector.addEventListener('change', () => {
 localeSelector.innerHTML = Object.entries(locales).map(e => `<option value="${e[0]}">${e[1].localeName}</option>`).join('')
 
 const ctx = canvas.getContext('2d');
-ctx.font = '18px xkcd-script';
-ctx.textBaseline ='top';
+ctx.font = '18px xkcd-script, Comic Sans MS, cursive';
+ctx.textBaseline = 'top';
 
 document.querySelectorAll('input').forEach(input => {
 	input.addEventListener('input', draw);
@@ -82,21 +86,27 @@ function draw() {
 	ctx.fillStyle = '#FFF';
 	ctx.fillRect(26, 21, 241, 114);
 	ctx.fillRect(88, 150, 181, 16);
+	ctx.fillRect(26, 177, 85, 18);
+	ctx.fillRect(0, 395, 295, 85);
 	
 	ctx.fillStyle = '#000';
 	ctx.textAlign = 'left';
-	textWrap(text1.toUpperCase(), 10, 10, 280, 130)
-	ctx.font = '18px xkcd-script';
+	textWrap(text1.toUpperCase(), 10, 10, 280, 130, true)
+	ctx.font = '18px xkcd-script, Comic Sans MS, cursive';
 	ctx.textAlign = 'right';
 	ctx.fillText(text2.toUpperCase(), 285, 150, 220)
+  ctx.font = '17px xkcd-script, Comic Sans MS, cursive';
+	ctx.fillText(currentLocale.ofCourse.toUpperCase(), 110, 178)
+  ctx.textAlign = 'center';
+	textWrap(currentLocale.textUnder.toUpperCase(), 147, 395, 285, 85, false)
 }
 
-function textWrap(text, x, y, width, height) {
+function textWrap(text, x, y, width, height, alignBottom) {
 	let words = text.split(/\s+/);
 	let currentLine = '';
 	let wrappedText = [];
 	let fontSize = 18;
-	for(let i = 0; i < words.length; i++) {
+	for (let i = 0; i < words.length; i++) {
 		let testLine = currentLine ? currentLine + ' ' + words[i] : words[i];
 		if (ctx.measureText(testLine).width > width && currentLine) {
 			wrappedText.push(currentLine);
@@ -109,12 +119,12 @@ function textWrap(text, x, y, width, height) {
 	
 	if (wrappedText.length * fontSize > height) {
 		fontSize = height / wrappedText.length;
-		ctx.font = `${fontSize}px xkcd-script`;
+		ctx.font = `${fontSize}px xkcd-script, Comic Sans MS, cursive`;
 	}
 	
 	let blockHeight = fontSize * wrappedText.length
-	if (blockHeight < height) {
-		y = 10 + height - blockHeight;
+	if (blockHeight < height && alignBottom) {
+		y += height - blockHeight;
 	}
 	
 	for (let i = 0; i < wrappedText.length; i++) {


### PR DESCRIPTION
I coded myself (fine, I used DeepL to check how to translate "feldspars", I'm not a geochemist) a basic implementation of how i18n could work. At this point is just translates strings defined in script.js, which aren't a lot, but were enough for a basic implementation of this feature.

From this, I guess the main roadblocks for implementing this are:

1. At the moment the script does not handle the entire contents of the comic, which is issue #6. When that issue gets fixed, then it would be way easier to localize the entire comic.
2. The xkcd-script font does not support A LOT of characters, which is [xkcd-font's issue 11](https://github.com/ipython/xkcd-font/issues/11). One can fork this project and add the missing characters, the font is under CC BY-NC 3.0, not a huge problem (I say that after years fixing fonts with missing accents when fansubbing anime, you just need to get used to a font editor, but I know I'm biased).

(I hope people can work together on this, I'm enthusiastic to make it work so I can post this edited comic on a Portuguese-speaking engineer Discord chat.)